### PR TITLE
Improve error reporting for OpenAI failures

### DIFF
--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -32,7 +32,12 @@ export const ChatWindow: React.FC = () => {
       messages,
       onChunk: (d) => appendAssistantDelta(assistId, d),
       onDone: () => { endAssistant(assistId); setLoading(false) },
-      onError: (e) => { push({ type: 'error', msg: 'สตรีมล้มเหลว' }); endAssistant(assistId); setLoading(false) },
+      onError: (e) => {
+        const msg = e instanceof Error ? e.message : 'สตรีมล้มเหลว'
+        push({ type: 'error', msg })
+        endAssistant(assistId)
+        setLoading(false)
+      },
       abortSignal: controller.signal
     })
   }

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -4,7 +4,11 @@ export async function listModels(apiKey: string) {
   const res = await fetch('https://api.openai.com/v1/models', {
     headers: { Authorization: `Bearer ${apiKey}` }
   })
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  if (!res.ok) {
+    let errText = ''
+    try { errText = await res.text() } catch {}
+    throw new Error(`HTTP ${res.status}: ${errText}`)
+  }
   const json = await res.json()
   return (json?.data ?? []) as Array<{ id: string }>
 }
@@ -41,7 +45,11 @@ export async function streamChat(opts: StreamOptions) {
       body: JSON.stringify(body),
       signal: abortSignal
     })
-    if (!res.ok || !res.body) throw new Error(`HTTP ${res.status}`)
+    if (!res.ok || !res.body) {
+      let errText = ''
+      try { errText = await res.text() } catch {}
+      throw new Error(`HTTP ${res.status}: ${errText}`)
+    }
 
     const reader = res.body.getReader()
     const decoder = new TextDecoder()


### PR DESCRIPTION
## Summary
- show detailed API error messages by reading response text when OpenAI requests fail
- surface the returned error in the chat UI toast

## Testing
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cb3cf6948331a6a75ce00684bea1