### PR TITLE
Fix build script and clean up TypeScript errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "node ./node_modules/typescript/bin/tsc -b && vite build",
     "preview": "vite preview --port 5173",
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write .",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { Toolbar } from './components/Toolbar'
 import { SessionList } from './components/SessionList'
 import { ChatWindow } from './components/ChatWindow'

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react'
+import { useRef, useState, type FC } from 'react'
 import { useChat } from '../contexts/ChatContext'
 import { MessageList } from './MessageList'
 import { MessageInput } from './MessageInput'
@@ -7,7 +7,7 @@ import { streamChat } from '../utils/openai'
 import { useToast } from '../contexts/ToastContext'
 import { countTokensText } from '../utils/token'
 
-export const ChatWindow: React.FC = () => {
+export const ChatWindow: FC = () => {
   const { conversations, currentId, addMessage, startAssistant, appendAssistantDelta, endAssistant } = useChat()
   const { settings } = useSettings()
   const { push } = useToast()
@@ -31,8 +31,8 @@ export const ChatWindow: React.FC = () => {
       systemPrompt: settings.systemPrompt,
       messages,
       onChunk: (d) => appendAssistantDelta(assistId, d),
-      onDone: () => { endAssistant(assistId); setLoading(false) },
-      onError: (e) => { push({ type: 'error', msg: 'สตรีมล้มเหลว' }); endAssistant(assistId); setLoading(false) },
+      onDone: () => { endAssistant(); setLoading(false) },
+      onError: () => { push({ type: 'error', msg: 'สตรีมล้มเหลว' }); endAssistant(); setLoading(false) },
       abortSignal: controller.signal
     })
   }

--- a/src/components/ModelSelect.tsx
+++ b/src/components/ModelSelect.tsx
@@ -1,13 +1,13 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState, type FC } from 'react'
 import { MODEL_PRICING } from '../constants/modelPricing'
 import { useSettings } from '../contexts/SettingsContext'
 import { listModels } from '../utils/openai'
 import { useToast } from '../contexts/ToastContext'
 
-export const ModelSelect: React.FC = () => {
+export const ModelSelect: FC = () => {
   const { settings, setSettings } = useSettings()
   const { push } = useToast()
-  const [models, setModels] = useState<string[]>(MODEL_PRICING.map(m => m.name))
+  const [, setModels] = useState<string[]>(MODEL_PRICING.map(m => m.name))
   const groups = MODEL_PRICING.reduce<Record<string, string[]>>((acc, m) => {
     acc[m.group] = acc[m.group] || []
     acc[m.group].push(m.name)

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
+import { type FC } from 'react'
 import { useChat } from '../contexts/ChatContext'
 
-export const SessionList: React.FC = () => {
-  const { index, conversations, currentId, setCurrentId, renameChat } = useChat()
+export const SessionList: FC = () => {
+  const { index, conversations, currentId, setCurrentId } = useChat()
 
   return (
     <div className="w-64 shrink-0 border-r dark:border-neutral-800 overflow-y-auto h-[calc(100vh-48px)]">

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -19,7 +19,7 @@ type ChatCtxType = {
   addMessage: (msg: Omit<Message, 'id'>) => void
   startAssistant: () => string // returns assistant message id
   appendAssistantDelta: (id: string, delta: string) => void
-  endAssistant: (id: string) => void
+  endAssistant: () => void
   newChat: () => void
   deleteChat: (id: string) => void
   deleteAll: () => void
@@ -122,12 +122,12 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
     if (!currentId) return ''
     const id = uuid()
     const conv = conversations[currentId]
-    const nextConv = {
+    const nextConv: Conversation = {
       ...conv,
       updatedAt: Date.now(),
       messages: [...conv.messages, { id, role: 'assistant', content: '' }],
     }
-    const next = { ...conversations, [currentId]: nextConv }
+    const next: Record<string, Conversation> = { ...conversations, [currentId]: nextConv }
     void save(next)
     return id
   }
@@ -145,10 +145,10 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setConversations(next) // update UI ทันที
   }
 
-  const endAssistant = (id: string) => {
+  const endAssistant = () => {
     if (!currentId) return
     const conv = conversations[currentId]
-    const next = {
+    const next: Record<string, Conversation> = {
       ...conversations,
       [currentId]: { ...conv, updatedAt: Date.now() },
     }

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react'
 import type { Settings } from '../types'
-import { MODEL_PRICING, type ModelName } from '../constants/modelPricing'
+import { MODEL_PRICING } from '../constants/modelPricing'
 
 const defaultSettings: Settings = {
   apiKey: '',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,8 +19,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "types": [
-      "vite/client",
-      "vitest/globals"
+      "vite/client"
     ]
   },
   "include": [


### PR DESCRIPTION
## Summary
- run the TypeScript compiler through Node to avoid permission issues
- tidy components and contexts by removing unused imports and parameters
- drop vitest type requirement to simplify compilation

## Testing
- `npm run build` *(fails: Cannot find declaration files / modules)*
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d1941bc88331842a1a11f4afa0bd