### PR TITLE
chore: ignore node modules in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Ignore node modules and other unnecessary files
+node_modules
+.git
+.gitignore
+Dockerfile
+npm-debug.log
+.env
+
+# Build output
+build
+out
+coverage
+dist


### PR DESCRIPTION
## Summary
- avoid copying local `node_modules` into Docker images by ignoring them in build context

## Testing
- `npm ci` *(fails: hung due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d1941bc88331842a1a11f4afa0bd